### PR TITLE
fix: gitignore workdir/nanos-secure-sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 \.idea/
 .DS_Store
 *.o
-./workdir/nano-secure-sdk/*å
+workdir/nanos-secure-sdk


### PR DESCRIPTION
the line in gitignore did not have the "s" on "nano", had an unnecessary `./` at the beginning, and had an unexpected character at the end