### PR TITLE
Ledger can show full Account ID now

### DIFF
--- a/workdir/app-near/src/context.h
+++ b/workdir/app-near/src/context.h
@@ -7,13 +7,13 @@
 
 // A place to store information about the transaction
 // for displaying to the user when requesting approval
-// 44 for address/id and +1 for \0
+// 64 for address/id and +1 for \0
 typedef struct uiContext_t {
-	char line1[45];
-	char line2[45];
-	char line3[45];
-	char line5[45];
-	char amount[45];
+	char line1[65];
+	char line2[65];
+	char line3[65];
+	char line5[65];
+	char amount[65];
 	char long_line[250];
 } uiContext_t;
 

--- a/workdir/app-near/test/main.c
+++ b/workdir/app-near/test/main.c
@@ -18,6 +18,7 @@ uiContext_t ui_context;
 // Transactions to test
 static const char TRANSFER_1_TRANSACTION_HEX[] = "18000000746573742d636f6e6e6563742d6c65646765722e746573740072068e029a9809c7f2da79c8a274743ff5f7edce24d648bd13e97f7093a03132040000000000000002000000766750dc6e47ddccb2421f27dec206d5ea4694422a1c2fc35ca8c2e3638a02aacf4b0100000003000040bd8b5b936b6c00000000000000";
 static const char TRANSFER_2_TRANSACTION_HEX[] = "17000000746573742d70722d3531372d6c65646765722e746573740072068e029a9809c7f2da79c8a274743ff5f7edce24d648bd13e97f7093a0313201000000000000000200000076674241eecd753a851429e4b415eb139dda037f705960200aa7a946bf24469b646e0100000003000000a1edccce1bc2d3000000000000";
+static const char TRANSFER_3_TRANSACTION_HEX[] = "40000000746573745f6163635f325f6161616161616161616161616161616161616161616161616161616161616161616161616161616161616161622e746573746e657400c002dcb1dfe53fc741447b28257990e4d907bf5e8a250211e4d4018748b7b247010000000000000040000000746573745f6163635f61616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161622e746573746e6574112dbb2bb983c64df7e1da1b73d3423177f3af489cd22fcd90ce88511b5fc39301000000030000e0f6117ee6d70b1a000000000000";
 static const char FUNCTION_CALL_TRANSACTION_HEX[] = "02000000766700dc9f5db36de8b6b403cf579db5425229175dacf5d1c7f10f1a685cbd7cca827e54000000000000000d00000072656365697665722e686572653a79b73517027a94f37203b95b6bb02fd4fb3764f1d689e04adcf54bf372573801000000020b0000006d6574686f645f6e616d650f0000007b2261726773223a2268657265227d00008a5d784563010000004a48011416954508000000000000c185e79a1fa205b9845d992cfa848c0a7bb036a1e0b8a3a4c19fcfb73d03ab5ab1559e8b6b3c37fa6c711159a191ab56be6565512bafc0178ac8326c73c4aa08";
 static const char CREATE_ACC_TRANSACTION_HEX[] = "1000000072616e646f6d5f616363312e6e65617200fec7bcd20067927cfab115c72f77c9975b4157e665a0ba3aba382ec03986297901000000000000001000000072616e646f6d5f616363322e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef60100000000";
 static const char DEPLOY_CONTRACT_TRANSACTION_HEX[] = "1000000072616e646f6d5f616363312e6e65617200fec7bcd20067927cfab115c72f77c9975b4157e665a0ba3aba382ec03986297901000000000000001000000072616e646f6d5f616363322e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef60100000001080000000000000000000000";
@@ -77,6 +78,21 @@ static char *test_parse_transfer_2()
     mu_assert("parses receiver", strcmp(ui_context.line2, "vg") == 0);
     mu_assert("parses signer", strcmp(ui_context.line3, "test-pr-517-ledger.test") == 0);
     mu_assert("parses amount", strcmp(ui_context.amount, "1") == 0);
+    mu_assert("line 4 empty", strcmp(ui_context.long_line, "") == 0);
+    mu_assert("line 5 empty", strcmp(ui_context.line5, "") == 0);
+    mu_assert("uses transfer flow", active_flow == SIGN_FLOW_TRANSFER);
+    return 0;
+}
+
+static char *test_parse_transfer_3()
+{
+    tmp_ctx.signing_context.buffer_used = PARSE_HEX(tmp_ctx.signing_context.buffer, TRANSFER_3_TRANSACTION_HEX);
+    int active_flow = parse_transaction();
+    mu_assert("parses action", strcmp(ui_context.line1, "transfer") == 0);
+    // accounts with max Account ID length (64 characters)
+    mu_assert("parses receiver", strcmp(ui_context.line2, "test_acc_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab.testnet") == 0);
+    mu_assert("parses signer", strcmp(ui_context.line3, "test_acc_2_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab.testnet") == 0);
+    mu_assert("parses amount", strcmp(ui_context.amount, "0.123") == 0);
     mu_assert("line 4 empty", strcmp(ui_context.long_line, "") == 0);
     mu_assert("line 5 empty", strcmp(ui_context.line5, "") == 0);
     mu_assert("uses transfer flow", active_flow == SIGN_FLOW_TRANSFER);
@@ -207,6 +223,7 @@ static char *all_tests()
 {
     mu_run_test(test_parse_transfer_1);
     mu_run_test(test_parse_transfer_2);
+    mu_run_test(test_parse_transfer_3);
     mu_run_test(test_parse_function_call);
     mu_run_test(test_parse_create_account);
     mu_run_test(test_parse_deploy_contract);


### PR DESCRIPTION
NEAR Account ID can be up to 64 bytes long, that is why we need to increase the buffer size of UI Context.