### PR TITLE
Increase transaction size limit for Ledger Nano X

### DIFF
--- a/workdir/app-near/src/constants.h
+++ b/workdir/app-near/src/constants.h
@@ -1,7 +1,20 @@
 #ifndef __CONSTANTS_H__
 #define __CONSTANTS_H__
 
+// Hardware dependent limits:
+//   Ledger Nano X has 32K RAM
+//   Ledger Nano S has 4K RAM
+#if defined(TARGET_NANOX) || defined(TARGET_NANOS2)
+
+// Ledger Nano X or Nano S Plus
+#define MAX_DATA_SIZE 10000
+
+#else
+
+// Ledger Nano S
 #define MAX_DATA_SIZE 650
+
+#endif
 
 // Host innteration communication protocol
 #define CLA 0x80                // CLASS? 


### PR DESCRIPTION
So as Ledger Nano X has 32K RAM, it allows us to increase the limit of transaction size for this device. 
Reference for this approach was found in [LedgerHQ/app-xrp](https://github.com/LedgerHQ/app-xrp/blob/7562eb56605f954702a9139f235b57ef7f1fb603/src/limitations.h#L35).